### PR TITLE
Add find_resource_slot() and remove unused deps

### DIFF
--- a/fabrictestbed/__init__.py
+++ b/fabrictestbed/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "2.0.3"
+__version__ = "2.0.4"
 __VERSION__ = __version__

--- a/fabrictestbed/external_api/orchestrator_client.py
+++ b/fabrictestbed/external_api/orchestrator_client.py
@@ -918,6 +918,48 @@ class OrchestratorClient:
         data = (payload.get("data") or [{}])
         return data[0] if data else {}
 
+    def find_resource_slot(
+        self,
+        *,
+        token: str,
+        start: datetime,
+        end: datetime,
+        duration: int,
+        resources: List[Dict[str, Any]],
+        max_results: int = 1,
+    ) -> Dict[str, Any]:
+        """
+        Find time windows where requested resources are simultaneously available.
+
+        :param token: FABRIC identity token
+        :param start: start of the search window
+        :param end: end of the search window
+        :param duration: required slot length in hours
+        :param resources: list of resource requirement dicts
+        :param max_results: maximum number of slots to return
+        :returns: dict with slot results
+        """
+        if not token:
+            raise OrchestratorValidationError("Token must be specified")
+        if not start or not end:
+            raise OrchestratorValidationError("Start and end must be specified")
+        if duration <= 0:
+            raise OrchestratorValidationError("Duration must be greater than 0")
+        if not resources:
+            raise OrchestratorValidationError("Resources must be specified")
+
+        body: Dict[str, Any] = {
+            "start": start.strftime(self.TIME_FORMAT),
+            "end": end.strftime(self.TIME_FORMAT),
+            "duration": duration,
+            "resources": resources,
+            "max_results": max_results,
+        }
+        resp = self._req("POST", "/resources/find-slot", token=token, json_body=body)
+        payload = self._json(resp)
+        data = payload.get("data") or [{}]
+        return data[0] if data else {}
+
     def renew(self, *, token: str, slice_id: str, new_lease_end_time: str) -> None:
         if not token or not slice_id or not new_lease_end_time:
             raise OrchestratorValidationError("Token, slice_id, and new_lease_end_time must be specified")

--- a/fabrictestbed/fabric_manager_v2.py
+++ b/fabrictestbed/fabric_manager_v2.py
@@ -587,6 +587,37 @@ class FabricManagerV2(TopologyQueryAPI):
             return_fmt=return_fmt,
         )
 
+    def find_resource_slot(
+        self,
+        *,
+        start: datetime,
+        end: datetime,
+        duration: int,
+        resources: List[Dict[str, Any]],
+        max_results: int = 1,
+        id_token: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        Find time windows where requested resources are simultaneously available.
+
+        :param start: start of the search window
+        :param end: end of the search window
+        :param duration: required slot length in hours
+        :param resources: list of resource requirement dicts
+        :param max_results: maximum number of slots to return
+        :param id_token: Optional FABRIC ID token. If not provided, uses stored/auto-refreshed token.
+        :returns: dict with slot results
+        """
+        token = self.ensure_valid_id_token(id_token)
+        return self.orch.find_resource_slot(
+            token=token,
+            start=start,
+            end=end,
+            duration=duration,
+            resources=resources,
+            max_results=max_results,
+        )
+
     def modify_slice(
         self, *, slice_id: str, graph_model: str, id_token: Optional[str] = None, return_fmt: Literal["dict", "dto"] = "dict"
     ) -> List[Union[Dict[str, Any], SliverDTO]]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,10 +18,8 @@ keywords = ["Swagger", "FABRIC Python Client Library"]
 requires-python = '>=3.9'
 dependencies = [
     "fabric_fss_utils>=1.5.1",
-    "click",
     "fabric-credmgr-client==1.6.2",
     "fabric-orchestrator-client==1.9.1",
-    "paramiko"
     ]
 
 [project.optional-dependencies]
@@ -29,7 +27,8 @@ test = ["coverage>=4.0.3",
         "nose>=1.3.7",
         "pluggy>=0.3.1",
         "py>=1.4.31",
-        "randomize>=0.13"
+        "randomize>=0.13",
+        "click"
         ]
 
 [project.urls]


### PR DESCRIPTION
## Summary
- Add `find_resource_slot()` to `OrchestratorClient` and `FabricManagerV2` — POST to `/resources/find-slot` to find time windows where requested resources are simultaneously available
- Remove unused dependencies: `click` (moved to test extras), `paramiko` (not imported)

## Test plan
- [x] `python3 -c "from fabrictestbed.external_api.orchestrator_client import OrchestratorClient"` passes
- [x] `python3 -c "from fabrictestbed.fabric_manager_v2 import FabricManagerV2"` passes
- [x] Verify `pip install .` succeeds without click/paramiko in main deps