### PR TITLE
Fix quota usage updates rejected with 400 by the Core API

### DIFF
--- a/fabrictestbed/__init__.py
+++ b/fabrictestbed/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "2.0.8"
+__version__ = "2.0.9"
 __VERSION__ = __version__

--- a/fabrictestbed/external_api/core_api.py
+++ b/fabrictestbed/external_api/core_api.py
@@ -25,7 +25,7 @@
 import datetime
 import json
 import logging
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any, Optional, Union
 
 import requests
 
@@ -318,10 +318,10 @@ class CoreApi:
         """
         data = {
             "project_uuid": project_uuid,
-            "resource_type": resource_type,
-            "resource_unit": resource_unit,
-            "quota_used": quota_used,
-            "quota_limit": quota_limit
+            "resource_type": self.resource_name(resource_type),
+            "resource_unit": self.resource_name(resource_unit),
+            "quota_used": float(quota_used),
+            "quota_limit": float(quota_limit)
         }
         response = requests.post(f'{self.api_server}/quotas', headers=self.headers, json=data)
         self.raise_for_status(response=response)
@@ -343,59 +343,87 @@ class CoreApi:
         logging.debug(f"GET Quotas Response : {response.json()}")
         return response.json().get("results")
 
+    @staticmethod
+    def resource_name(value: Union[str, dict, None]) -> Optional[str]:
+        """
+        Normalize a quota field that the Core API may return either as a plain string or as an object.
+
+        GET /quotas returns `resource_type` as an object ({"name": ..., "value": ...}) per the
+        `quotas_one_resource_type` schema, while the POST and PUT payloads declare it as a plain string.
+        Passing the object form straight back fails OpenAPI validation with a 400 before the request
+        ever reaches the handler.
+
+        Parameters:
+        value: the raw value read from a quota record, either a string or a {"name": ...} object.
+
+        Returns:
+        Optional[str]: the string form suitable for a quota payload, or None if there is no value.
+        """
+        if isinstance(value, dict):
+            return value.get("name")
+        return value
+
     def update_quota_usage(self, uuid: str, project_uuid: str, quota_used: float):
         """
         Send a PUT request to update a quota usage by UUID.
 
+        Reads the current usage for the quota and adds `quota_used` to it, flooring the result at 0.
+
+        Only `quota_used` is sent. The quota is identified by `uuid` in the path and `quotas_put`
+        declares no required properties, so the resource type, unit and limit are left untouched
+        rather than being read back and echoed -- echoing them can only ever re-send a value the
+        server already has, and it is what previously made this call fail validation outright.
+
         Parameters:
         uuid (str): The UUID of the quota to update.
         project_uuid (str): The ID of the project to which the quota belongs.
-        quota_used (int, optional): The amount of resource currently used.
+        quota_used (float): The amount of resource to add to the current usage; may be negative.
 
         Returns:
         List[dict]: The updated quota details.
         """
         current_quota = self.get_quota(uuid=uuid)[0]
 
-        value = current_quota.get("quota_used") + quota_used
+        value = float(current_quota.get("quota_used") or 0) + quota_used
         if value < 0:
             value = 0
 
-        data = {
-            "project_uuid": project_uuid,
-            "resource_type": current_quota.get("resource_type"),
-            "resource_unit": current_quota.get("resource_unit"),
-            "quota_used": value,
-            "quota_limit": current_quota.get("quota_limit")
-        }
-        response = requests.put(f'{self.api_server}/quotas/{uuid}', headers=self.headers, json=data)
-        self.raise_for_status(response=response)
-        logging.debug(f"PUT Quotas Response : {response.json()}")
-        return response.json().get("results")
+        return self.update_quota(uuid=uuid, project_uuid=project_uuid, quota_used=value)
 
-    def update_quota(self, uuid: str, project_uuid: str, resource_type: str, resource_unit: str,
-                     quota_used: float = 0, quota_limit: float = 0):
+    def update_quota(self, uuid: str, project_uuid: str, resource_type: Union[str, dict] = None,
+                     resource_unit: Union[str, dict] = None, quota_used: float = None,
+                     quota_limit: float = None):
         """
         Send a PUT request to update a quota by UUID.
+
+        This is a partial update: any parameter left as None is omitted from the payload and the server
+        keeps its current value. `quotas_put` declares every property as an optional string or number,
+        so a null is rejected outright -- and one null takes the whole payload down with it, not just
+        its own field.
 
         Parameters:
         uuid (str): The UUID of the quota to update.
         project_uuid (str): The ID of the project to which the quota belongs.
-        resource_type (str): The type of resource (e.g., CPU, RAM).
-        resource_unit (str): The unit of the resource (e.g., cores, GB).
-        quota_used (int, optional): The amount of resource currently used. Defaults to 0.
-        quota_limit (int, optional): The limit for the resource. Defaults to 0.
+        resource_type (str, optional): The type of resource (e.g., CPU, RAM). Also accepts the object
+                                       form returned by GET /quotas, in which case its "name" is used.
+        resource_unit (str, optional): The unit of the resource (e.g., cores, GB). Same object form
+                                       accepted.
+        quota_used (float, optional): The amount of resource currently used. Left unchanged if omitted.
+        quota_limit (float, optional): The limit for the resource. Left unchanged if omitted.
 
         Returns:
         List[dict]: The updated quota details.
         """
         data = {
             "project_uuid": project_uuid,
-            "resource_type": resource_type,
-            "resource_unit": resource_unit,
-            "quota_used": quota_used,
-            "quota_limit": quota_limit
+            "resource_type": self.resource_name(resource_type),
+            "resource_unit": self.resource_name(resource_unit),
+            "quota_used": None if quota_used is None else float(quota_used),
+            "quota_limit": None if quota_limit is None else float(quota_limit)
         }
+        data = {k: v for k, v in data.items() if v is not None}
+
+        logging.debug(f"PUT Quotas Request : {uuid} {data}")
         response = requests.put(f'{self.api_server}/quotas/{uuid}', headers=self.headers, json=data)
         self.raise_for_status(response=response)
         logging.debug(f"PUT Quotas Response : {response.json()}")


### PR DESCRIPTION
## Problem

Every `PUT /quotas/{uuid}` the broker sent was rejected: **3,602 requests, 3,602 × HTTP 400, zero 200s** over the observable log window (Aug 14–17), across 30 distinct quota UUIDs. Quota accounting in the Core API is completely unpopulated — all 5,678 quota rows read `quota_used = 0.00`.

## Root cause

`update_quota_usage()` did a `GET /quotas/{uuid}` and echoed the returned record into the PUT body:

```python
data = {
    ...
    "resource_type": current_quota.get("resource_type"),   # <- an OBJECT, not a string
}
```

Per the live spec (`uis.fabric-testbed.net/openapi.json`, Core API 1.11.3), `quotas_one.resource_type` is `quotas_one_resource_type` — an **object** with `name` and `value`. But `quotas_put.resource_type` is a plain `string`. So the body failed Connexion's request validation *before* `quotas_uuid_put()` ever ran.

That matches every symptom: ~2 ms rejection, constant 184-byte response, `X-Error: Validation error or other malformed request type:`, zero handler-level ERROR lines, and no 401s (auth was always fine).

## Fix

`quotas_put` declares **no required properties**, and the quota is identified by `uuid` in the path. The resource type, unit, and limit were only ever being read back and re-sent unchanged — so `update_quota_usage()` now sends just the field it means to change:

```json
{"project_uuid": "...", "quota_used": 12.5}
```

Also in this change:

- `update_quota()` **omits** any field left as `None` rather than sending `null`. A null is not a valid `number`/`string` under the schema, and one null takes the whole payload down with it, not just its own field.
- Optional params now default to `None`. **Behavior change:** `quota_limit` previously defaulted to `0`, so calling `update_quota()` without a limit silently zeroed a project's quota limit. For a partial-update endpoint, omission must mean "leave alone."
- New `resource_name()` unwraps the `{name, value}` object form, for callers that pass `resource_type`/`resource_unit` explicitly. Applied to `create_quota()` too, which has the same string schema.
- Numerics coerced with `float()` — a quoted number is rejected the same way an object is.
- `float(current_quota.get("quota_used") or 0)` — the old expression raised `TypeError` on a null usage.
- Log the outbound PUT payload. The API's 400 body carries no detail about which field was wrong, which is why this ran for days undiagnosed.

## Verification

Payloads validated with `jsonschema` against the `quotas_put` / `quotas_post` schemas pulled live from PROD — all six cases valid:

| case | body |
|---|---|
| usage update `+2.5` | `{"project_uuid": "p1", "quota_used": 12.5}` |
| usage update clamp at 0 | `{"project_uuid": "p1", "quota_used": 0.0}` |
| full update | `{..., "resource_type": "core", "resource_unit": "hours", "quota_used": 1.0, "quota_limit": 2.0}` |
| limit-only partial | `{"project_uuid": "p1", "quota_limit": 50.0}` |
| object-form arg | `{"project_uuid": "p1", "resource_type": "GPU"}` |
| `create_quota` | all four required fields present |

Also audited all 17 HTTP calls in `core_api.py` against the spec — every path/method exists, no undeclared or missing-required query params, `POST /sshkeys` satisfies `sshkeys_post`. The quota write path was the only broken one.

This is mock-level verification of payload shape; nothing was sent to PROD, so the 200 is unconfirmed until one real PUT goes out.

## Not addressed

- **`name` vs `value`.** `resource_name()` returns `name`. The spec documents both as bare strings with no example or enum, and `GET /quotas` needs a token, so I could not sample a real record to confirm which form the write path wants. This does not affect the broker (it now sends neither), only `create_quota()` and explicit `update_quota(resource_type=...)` calls. Evidence points to `name`: ControlFramework's `list_quotas()` keys off `name.lower()` and those keys matched real rows.
- **No backfill.** The usage that failed to post is unrecoverable — the broker computes per-reservation deltas with no replayable ledger. Accounting stays wrong after this ships; it just stops getting worse.
- `PUT`/`DELETE /quotas/{uuid}` return `status_200_ok_no_content`, not quota records, so both docstrings' "Returns: the updated quota details" is inaccurate. Left alone — changing the return value would break callers.

## Downstream

Version bumped to **2.0.9**. ControlFramework pins `fabrictestbed==2.0.9`, so **this needs to reach PyPI before the broker is redeployed.**
